### PR TITLE
Revert "変換後の文字のplaceholderのテキストが間違っていたため修正"

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,7 +144,7 @@ const App: Component = () => {
             <Textarea
               value={convertedVowel()}
               variant="unstyled"
-              placeholder="おいんえんあんい"
+              placeholder="おいいんいえんあんいあいおい"
               readOnly
               size="lg"
               py={!convertedVowel() ? "$2" : ""}


### PR DESCRIPTION
# 概要
- こちらの変更は不要だったためリバート