### PR TITLE
変換後の文字のplaceholderのテキストが間違っていたため修正 #21

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,7 +144,7 @@ const App: Component = () => {
             <Textarea
               value={convertedVowel()}
               variant="unstyled"
-              placeholder="おいいんいえんあんいあいおい"
+              placeholder="おいんい えんあんいあい おい"
               readOnly
               size="lg"
               py={!convertedVowel() ? "$2" : ""}


### PR DESCRIPTION
変換後の文字のplaceholderのテキストが間違っていたため修正
- 母音に変換後の文字を母音に変換した場合のテキストを表示させる
    - おいんい えんあんいあい おい